### PR TITLE
Add Phabricator integration

### DIFF
--- a/src/integrations/integrations.json
+++ b/src/integrations/integrations.json
@@ -233,6 +233,12 @@
     "script": "outlook.js",
     "clone": false
   },
+  "phacility.com": {
+    "name": "Phabricator",
+    "link": "*://*.phacility.com/*,*://phabricator.*",
+    "script": "phabricator.js",
+    "clone": false
+  },
   "pipefy.com": {
     "name": "Pipefy",
     "link": "*://app.pipefy.com/*",

--- a/src/integrations/phabricator.js
+++ b/src/integrations/phabricator.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// For a Maniphest task on a project workboard
+clockifyButton.render('.phui-workcard:not(.clockify)', {observe: true}, (elem) => {
+    var description = $('.phui-oi-objname', elem).textContent + ': ' + $('.phui-oi-link', elem).textContent.trim();
+    var link = clockifyButton.createSmallButton(description);
+    link.style.marginRight = '5px';
+    $('.phui-oi-name', elem).prepend(link);
+});
+
+// For a Maniphest task details page
+clockifyButton.render('.phui-header-view:not(.clockify)', {observe: true}, (elem) => {
+    var task_number = document.URL.split('/').pop();
+    // test if it is a task details page
+    if (! /^(T[0-9]+)$/.test(task_number)) {
+        return;
+    }
+    var description = task_number + ': ' + $('.phui-header-header').textContent.trim();
+    var link = clockifyButton.createButton(description);
+    $('.phui-header-subheader', elem).append(link);
+});
+
+// For a Maniphest task on dashboards
+clockifyButton.render('.phui-oi-content-box:not(.clockify)', {observe: true}, (elem) => {
+    var task_anchor = $('.phui-oi-link', elem);
+    var task_number = task_anchor.href.split('/').pop();
+    // test if it is a task element
+    if (! /^(T[0-9]+)$/.test(task_number) || document.URL.includes('board')) {
+        return;
+    }
+    var description = task_number + ': ' + task_anchor.textContent.trim();
+    var link = clockifyButton.createButton(description);
+    $('.phui-oi-attributes', elem).append(link);
+});


### PR DESCRIPTION
Phabricator is a suite of web-based software development collaboration tools.

Note: Though the `*://*.phacility.com/*` pattern should make the extension work on `https://test-mysite.phacility.com/` by default, I couldn't get it to work without adding a custom domain. I tested on two custom domains `https://test-mysite.phacility.com/` and `https://phabricator.mysite.com/` and it works as expected.

**screenshots:**

![image](https://user-images.githubusercontent.com/6003890/60401016-eb7dd900-9b90-11e9-9328-dadfc2456148.png)
![image](https://user-images.githubusercontent.com/6003890/60401030-0c462e80-9b91-11e9-9618-ce73fc5638c5.png)
![image](https://user-images.githubusercontent.com/6003890/60401038-2253ef00-9b91-11e9-95c1-08cf0ee8075e.png)
