### PR TITLE
fix phabricator integration with duplicate clockify icons

### DIFF
--- a/src/integrations/phabricator.js
+++ b/src/integrations/phabricator.js
@@ -25,7 +25,7 @@ clockifyButton.render('.phui-oi-content-box:not(.clockify)', {observe: true}, (e
     var task_anchor = $('.phui-oi-link', elem);
     var task_number = task_anchor.href.split('/').pop();
     // test if it is a task element
-    if (! /^(T[0-9]+)$/.test(task_number) || document.URL.includes('board')) {
+    if (! /^(T[0-9]+)$/.test(task_number) || document.URL.includes('/project/') || document.URL.includes('/tag/')) {
         return;
     }
     var description = task_number + ': ' + task_anchor.textContent.trim();


### PR DESCRIPTION
Phabricator's integration uses the document URL to determine whether a Clockify button is needed or not. There are multiple URL patterns pointing to a single project board. Tags are also projects in Phabricator environment. 

This fix prevents duplicate Clockify buttons appearing on a card in a project board when reaching the board from different URL patterns.