### PR TITLE
Fixed button styling for Gitlab integration.

### DIFF
--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -14,6 +14,8 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
 
     link = clockifyButton.createButton(description);
     link.style.marginRight = '15px';
+    link.style.padding = '0px';
+    link.style.paddingLeft = '20px';
     actionsElem.parentElement.insertBefore(link, actionsElem);
 });
 
@@ -32,6 +34,8 @@ clockifyButton.render('.merge-request-details .detail-page-description:not(.cloc
 
     link = clockifyButton.createButton(description);
     link.style.marginRight = '15px';
+    link.style.padding = '0px';
+    link.style.paddingLeft = '20px';
     actionsElem.parentElement.insertBefore(link, actionsElem);
 });
 


### PR DESCRIPTION
Fixed button styling for Gitlab integration.

**Before:**
<img width="1170" alt="Screen Shot 2019-08-22 at 04 04 29" src="https://user-images.githubusercontent.com/9222368/63478324-12ba9d80-c492-11e9-9f1d-ac30c5cbffb0.png">

**After:**
<img width="1180" alt="Screen Shot 2019-08-22 at 04 04 44" src="https://user-images.githubusercontent.com/9222368/63478322-0e8e8000-c492-11e9-9691-37fcc5987e11.png">