### PR TITLE
Use webpack --env for powershell/cmd building support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "clean.build.chrome.dev": "node tools/clean-build-script.js www/chrome.dev/",
     "clean.build.firefox.dev": "node tools/clean-build-script.js www/firefox.dev/",
-    "compile.dev.chrome": "npm run clean.build.chrome.dev && compass compile -c config_chrome.dev.rb && TARGET=chrome.dev webpack --watch",
-    "compile.dev.firefox": "npm run clean.build.firefox.dev && compass compile -c config_firefox.dev.rb && TARGET=firefox.dev webpack",
+    "compile.dev.chrome": "npm run clean.build.chrome.dev && compass compile -c config_chrome.dev.rb && webpack --env.TARGET=chrome.dev --watch",
+    "compile.dev.firefox": "npm run clean.build.firefox.dev && compass compile -c config_firefox.dev.rb && webpack --env.TARGET=firefox.dev --watch",
     "copy.assets": "node tools/copy-assets-from-node-modules.js"
   },
   "author": "",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,12 +5,12 @@ const serviceVersion = require("./package.json").version;
 
 const DEV = !process.env.NODE_ENV || process.env.NODE_ENV !== 'prod';
 
-module.exports = {
+module.exports = env => { return {
     entry: [
         'babel-polyfill', './src/main.js'
     ],
     output: {
-        path: path.join(__dirname, `www/${process.env.TARGET}`),
+        path: path.join(__dirname, `www/${env.TARGET}`),
         filename: '[name].bundle.js',
     },
     optimization: {
@@ -44,7 +44,7 @@ module.exports = {
             {from: './assets', to: './assets'},
             {from: './styles', to: './styles'},
             {from: `./index.html`, to: './'},
-            {from: `./manifest.${process.env.TARGET}.json`, to: `./manifest.json`},
+            {from: `./manifest.${env.TARGET}.json`, to: `./manifest.json`},
             {from: './src/contentScripts', to: './contentScripts'},
             {from: './src/integrations', to: './integrations'},
             {from: './src/settings.html', to: './'},
@@ -52,4 +52,4 @@ module.exports = {
         ]),
         new webpack.DefinePlugin({'serviceVersion': JSON.stringify(serviceVersion)})
     ]
-};
+}; };


### PR DESCRIPTION
closes #30

Also, minor note, but chrome official extension version is higher than the version here (1.7.5 vs 1.7.4).

For technical reference: https://webpack.js.org/guides/environment-variables/