### PR TITLE
always hit API for current task

### DIFF
--- a/src/contentScripts/webSocket-background.js
+++ b/src/contentScripts/webSocket-background.js
@@ -11,7 +11,6 @@ const webSocketEventsEnums = {
 };
 Object.freeze(webSocketEventsEnums);
 
-document.isFirstTimeSettingTimeEntry = true;
 let connection;
 
 let onErrorReconnectTimeout;
@@ -168,27 +167,19 @@ aBrowser.runtime.onMessage.addListener((request, sender, sendResponse) => {
             }
             break;
         case "getEntryInProgress":
-            if (
-                (!document.timeEntry || document.timeEntry === undefined) &&
-                    document.isFirstTimeSettingTimeEntry
-            ) {
-                document.isFirstTimeSettingTimeEntry = false;
-                this.getEntryInProgress().then(response => response.json()).then(data => {
-                    this.entryInProgressChangedEventHandler(data);
-                    sendResponse(document.timeEntry);
-                    aBrowser.browserAction.setIcon({
-                        path: iconPathStarted
-                    });
-                }).catch(() => {
-                    this.entryInProgressChangedEventHandler(null);
-                    sendResponse(document.timeEntry);
-                    aBrowser.browserAction.setIcon({
-                        path: iconPathEnded
-                    });
-                });
-            } else {
+            this.getEntryInProgress().then(response => response.json()).then(data => {
+                this.entryInProgressChangedEventHandler(data);
                 sendResponse(document.timeEntry);
-            }
+                aBrowser.browserAction.setIcon({
+                    path: iconPathStarted
+                });
+            }).catch(() => {
+                this.entryInProgressChangedEventHandler(null);
+                sendResponse(document.timeEntry);
+                aBrowser.browserAction.setIcon({
+                    path: iconPathEnded
+                });
+            });
             break;
     }
 });


### PR DESCRIPTION
The changes proposed here ensure that the extension is always able to pull the currently running task via the API. 

Without these changes, the extension only pulls the running task from the API once when it first runs. This results in inaccurate information in the extension after any page refresh and prevents the generated buttons from showing as active on a newly loaded page when they should.

I don't know if this is the best way to fix this, but it does work.

Note that I was unable to test this in Firefox, as the entire extension as it exists on this repository does not seem to work in Firefox at all. 