### PR TITLE
Automatic assignment to tasks

### DIFF
--- a/src/application-types/extension.js
+++ b/src/application-types/extension.js
@@ -175,7 +175,7 @@ export class Extension {
     }
 
     startTimer(request, sendResponse) {
-        startTimer(request.description || "", request.project, request.task)
+        startTimer(request.timeEntryOptions)
             .then((response) => {
                 if (!response.message) {
                     window.inProgress = true;

--- a/src/application-types/extension.js
+++ b/src/application-types/extension.js
@@ -175,7 +175,7 @@ export class Extension {
     }
 
     startTimer(request, sendResponse) {
-        startTimer(request.description || "", request.project)
+        startTimer(request.description || "", request.project, request.task)
             .then((response) => {
                 if (!response.message) {
                     window.inProgress = true;

--- a/src/components/settings.component.js
+++ b/src/components/settings.component.js
@@ -39,6 +39,7 @@ class Settings extends React.Component {
             userEmail: '',
             userPicture: null,
             sendErrors: JSON.parse(localStorageService.get('sendErrors')),
+            createObjects: JSON.parse(localStorageService.get('createObjects', false)), // TODO what is the sensible default here?
             isSelfHosted: JSON.parse(localStorageService.get('selfHosted', false)),
             idleDetection: false,
             idleDetectionCounter: null,
@@ -193,6 +194,21 @@ class Settings extends React.Component {
             window.metricService.disable();
             this.setState({
                 sendErrors: true
+            });
+        }
+        this.showSuccessMessage();
+    }
+
+    toggleCreateObjects() {
+        if (this.state.createObjects) {
+            localStorageService.set('createObjects', false, getLocalStorageEnums().PERMANENT_PREFIX);
+            this.setState({
+                createObjects: false
+            });
+        } else {
+            localStorageService.set('createObjects', true, getLocalStorageEnums().PERMANENT_PREFIX);
+            this.setState({
+                createObjects: true
             });
         }
         this.showSuccessMessage();
@@ -728,6 +744,17 @@ class Settings extends React.Component {
                         workspaceSettings={this.props.workspaceSettings}
                         changeSaved={this.showSuccessMessage.bind(this)}
                     />
+                    <div className={isAppTypeExtension() ? "settings__send-errors" : "disabled"}
+                         onClick={this.toggleCreateObjects.bind(this)}>
+                        <span className={this.state.createObjects ?
+                            "settings__send-errors__checkbox checked" : "settings__send-errors__checkbox"}>
+                            <img src="./assets/images/checked.png"
+                                 className={this.state.createObjects ?
+                                     "settings__send-errors__checkbox--img" :
+                                     "settings__send-errors__checkbox--img_hidden"}/>
+                        </span>
+                        <span className="settings__send-errors__title">Create projects/tasks/tags if they're not existing</span>
+                    </div>
                     <DarkModeComponent
                         changeSaved={this.showSuccessMessage.bind(this)}
                     />

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -119,7 +119,9 @@ async function createTask(token, projectId, taskName) {
 
 async function getOrCreateTask(token, project, taskName) {
     // try to find the appropriate task for this
-    const task = project.tasks.find(t => t.name === taskName);
+    // if project.tasks is not present, this most certainly means that this
+    // project was freshly created in which case there simply are no tasks
+    const task = (project.tasks || []).find(t => t.name === taskName);
 
     return task || (await createTask(token, project.id, taskName));
 }

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -149,8 +149,16 @@ async function getOrCreateTags(tagNames) {
 async function startTimeEntryRequestAndFetch (timeEntryUrl, token, options) {
     const headers =  new Headers(httpHeadersHelper.createHttpHeaders(token));
     const project = await projectHelpers.getProjectForButton(options.projectName);
-    const task = options.taskName ? await getOrCreateTask(token, project, options.taskName) : null;
-    const tags = options.tagNames ? await getOrCreateTags(options.tagNames) : [];
+
+    let task = null;
+    if (project && options.taskName) {
+        task = await getOrCreateTask(token, project, options.taskName);
+    }
+
+    let tags = [];
+    if (options.tagNames) {
+        tags = await getOrCreateTags(options.tagNames);
+    }
 
     let billable = options.billable;
     if (billable === undefined || billable === null) {

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -1,4 +1,3 @@
-import * as _ from "lodash";
 import {TokenService} from "../services/token-service";
 import * as React from 'react';
 import {ProjectHelper} from "./project-helper";
@@ -154,7 +153,7 @@ async function startTimeEntryRequestAndFetch (timeEntryUrl, token, options) {
     const tags = options.tagNames ? await getOrCreateTags(options.tagNames) : [];
 
     let billable = options.billable;
-    if (_.isNil(billable)) {
+    if (billable === undefined || billable === null) {
         billable = project ? project.billable : false;
     }
 

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -123,7 +123,11 @@ async function getOrCreateTask(token, project, taskName) {
     // project was freshly created in which case there simply are no tasks
     const task = (project.tasks || []).find(t => t.name === taskName);
 
-    return task || (await createTask(token, project.id, taskName));
+    if (task) {
+        return task;
+    } else if (localStorageService.get('createObjects')) {
+        return await createTask(token, project.id, taskName);
+    }
 }
 
 async function getOrCreateTags(tagNames) {
@@ -140,7 +144,7 @@ async function getOrCreateTags(tagNames) {
         const t = existingTags.find(e => e.name === n);
         if (t) {
             tags.push(t);
-        } else {
+        } else if (localStorageService.get('createObjects')) {
             try {
                 const r = await tagService.createTag({ name: n });
                 if (r.status === 201) {

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -43,7 +43,7 @@ export function stopInProgress() {
     });
 }
 
-export function startTimer(description, projectName) {
+export function startTimer(description, projectName, taskName) {
     const activeWorkspaceId = localStorageService.get('activeWorkspaceId');
     const baseUrl = localStorageService.get('baseUrl');
     let timeEntryUrl =
@@ -51,7 +51,7 @@ export function startTimer(description, projectName) {
 
     return tokenService.getToken().then(token => {
         if (token) {
-            return startTimeEntryRequestAndFetch(timeEntryUrl, token, description, projectName);
+            return startTimeEntryRequestAndFetch(timeEntryUrl, token, description, projectName, taskName);
         } else {
             tokenService.logout();
             return new Promise((resolve, reject) => {
@@ -88,9 +88,18 @@ function createStopInProgressUrlAndFetch (endInProgressUrl, token) {
         .then(response => response);
 }
 
-async function startTimeEntryRequestAndFetch (timeEntryUrl, token, description, projectName) {
+async function startTimeEntryRequestAndFetch (timeEntryUrl, token, description, projectName, taskName) {
     const headers =  new Headers(httpHeadersHelper.createHttpHeaders(token));
     const project = await projectHelpers.getProjectForButton(projectName);
+
+    console.log("YEEEEYYY");
+    console.log(taskName);
+    console.log(project);
+
+    // try to find the appropriate task for this
+    const task = project.tasks.find(t => t.name === taskName);
+    console.log(task);
+
     const timeEntryRequest = new Request(timeEntryUrl, {
         method: 'POST',
         headers: headers,
@@ -100,7 +109,7 @@ async function startTimeEntryRequestAndFetch (timeEntryUrl, token, description, 
             billable: project ? project.billable : false,
             projectId: project ? project.id : null,
             tagIds: [],
-            taskId: null
+            taskId: task ? task.id : null
         })
     });
         return fetch(timeEntryRequest)

--- a/src/helpers/project-helper.js
+++ b/src/helpers/project-helper.js
@@ -150,7 +150,7 @@ export class ProjectHelper {
                     project = response.data.filter(project => project.name === projectName)[0];
                 }
 
-                if (!project) {
+                if (!project && localStorageService.get('createObjects')) {
                     return projectService.createProject({
                         name: projectName,
                         color: "#03a9f4"

--- a/src/helpers/project-helper.js
+++ b/src/helpers/project-helper.js
@@ -133,7 +133,7 @@ export class ProjectHelper {
         const page = 0;
         const pageSize = 50;
         let projectFilter;
-        let project;
+        let project = null;
 
         if (!!projectName) {
             const isSpecialFilter =
@@ -147,10 +147,30 @@ export class ProjectHelper {
 
             return projectService.getProjectsWithFilter(projectFilter, page, pageSize).then(response => {
                 if (response && response.data && response.data.length > 0) {
+                    console.log("FETCH");
+                    console.log(response);
                     project = response.data.filter(project => project.name === projectName)[0];
-                    return project ? project : this.getDefaultProject();
+                }
+
+                if (!project) {
+                    return projectService.createProject({
+                        name: projectName,
+                        color: "#03a9f4"
+                    }).then(response => {
+                        if (response.status === 201) {
+                            console.log("POST");
+                            console.log(response);
+                            return response.data;
+                        } else {
+                            // something went wrong, ignore and return default project
+                            return this.getDefaultProject();
+                        }
+                    }).catch(error => {
+                        console.error(error);
+                        return this.getDefaultProject();
+                    });
                 } else {
-                    return this.getDefaultProject();
+                    return project;
                 }
             });
         } else {

--- a/src/helpers/project-helper.js
+++ b/src/helpers/project-helper.js
@@ -147,8 +147,6 @@ export class ProjectHelper {
 
             return projectService.getProjectsWithFilter(projectFilter, page, pageSize).then(response => {
                 if (response && response.data && response.data.length > 0) {
-                    console.log("FETCH");
-                    console.log(response);
                     project = response.data.filter(project => project.name === projectName)[0];
                 }
 
@@ -158,8 +156,6 @@ export class ProjectHelper {
                         color: "#03a9f4"
                     }).then(response => {
                         if (response.status === 201) {
-                            console.log("POST");
-                            console.log(response);
                             return response.data;
                         } else {
                             // something went wrong, ignore and return default project

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -45,11 +45,23 @@ var clockifyButton = {
         }
     },
     createButton: (description, project, task) => {
+        let timeEntryOptions;
+        if (typeof description === 'object') {
+            // mode: only one parameter that contains the options
+            timeEntryOptions = description;
+        } else {
+            // legacy mode: multiple parameters
+            timeEntryOptions = {
+                description: description || "",
+                projectName: project || null,
+                taskName: task || null,
+                billable: null
+            };
+        }
+
         const button = document.createElement('a');
-        let title = invokeIfFunction(description);
+        let title = invokeIfFunction(timeEntryOptions.description);
         let active = title && title === clockifyButton.inProgressDescription;
-        const projectName = !!project ? project : null;
-        const taskName = !!task ? task : null;
 
         setButtonProperties(button, title, active);
 
@@ -58,7 +70,7 @@ var clockifyButton = {
         });
 
         button.onclick = () => {
-            title = invokeIfFunction(description);
+            title = invokeIfFunction(timeEntryOptions.description);
             if (title && title === clockifyButton.inProgressDescription) {
                 aBrowser.runtime.sendMessage({eventName: 'endInProgress'}, (response) => {
                     if (response.status === 400) {
@@ -75,9 +87,7 @@ var clockifyButton = {
             } else {
                 aBrowser.runtime.sendMessage({
                     eventName: 'startWithDescription',
-                    description: title,
-                    project: projectName,
-                    task: taskName
+                    timeEntryOptions: timeEntryOptions
                 }, (response) => {
                     if (response.status === 400) {
                         alert("Can't end entry without project/task/description or tags.Please edit your time entry.");

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -44,11 +44,12 @@ var clockifyButton = {
             renderer(element);
         }
     },
-    createButton: (description, project) => {
+    createButton: (description, project, task) => {
         const button = document.createElement('a');
         let title = invokeIfFunction(description);
         let active = title && title === clockifyButton.inProgressDescription;
         const projectName = !!project ? project : null;
+        const taskName = !!task ? task : null;
 
         setButtonProperties(button, title, active);
 
@@ -75,7 +76,8 @@ var clockifyButton = {
                 aBrowser.runtime.sendMessage({
                     eventName: 'startWithDescription',
                     description: title,
-                    project: projectName
+                    project: projectName,
+                    task: taskName
                 }, (response) => {
                     if (response.status === 400) {
                         alert("Can't end entry without project/task/description or tags.Please edit your time entry.");

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -165,6 +165,11 @@ function $(s, elem) {
     return elem.querySelector(s);
 }
 
+function $$(s, elem) {
+    elem = elem || document;
+    return elem.querySelectorAll(s);
+}
+
 function invokeIfFunction(trial) {
     if (trial instanceof Function) {
         return trial();

--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -20,9 +20,6 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
     link.style.marginRight = '15px';
     link.style.padding = '0px';
     link.style.paddingLeft = '20px';
-    if (billable) {
-        link.style.background = 'red';
-    }
     actionsElem.parentElement.insertBefore(link, actionsElem);
 });
 

--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -9,13 +9,13 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
         description = numElem.textContent.split(" ").pop().trim() + " " + description;
     }
 
-    var billable = Array.from($$("div.labels .gl-label-text")).some(e => e.innerText === "billable");
+    var tags = Array.from($$("div.labels .gl-label-text")).map(e => e.innerText);
 
     link = clockifyButton.createButton({
         description: description,
         projectName: projectElem.textContent.trim(),
         taskName: description,
-        billable: billable
+        tagNames: tags
     });
     link.style.marginRight = '15px';
     link.style.padding = '0px';

--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -9,7 +9,7 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
         description = numElem.textContent.split(" ").pop().trim() + " " + description;
     }
 
-    link = clockifyButton.createButton(description, projectElem.textContent.trim());
+    link = clockifyButton.createButton(description, projectElem.textContent.trim(), description);
     link.style.marginRight = '15px';
     link.style.padding = '0px';
     link.style.paddingLeft = '20px';
@@ -29,7 +29,7 @@ clockifyButton.render('.merge-request-details .detail-page-description:not(.cloc
         description = "MR" + numElem.textContent.split(" ").pop().trim().replace("!", "") + "::" + description;
     }
 
-    link = clockifyButton.createButton(description, projectElem.textContent.trim());
+    link = clockifyButton.createButton(description, projectElem.textContent.trim(), description);
     link.style.marginRight = '15px';
     link.style.padding = '0px';
     link.style.paddingLeft = '20px';

--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -9,7 +9,12 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
         description = numElem.textContent.split(" ").pop().trim() + " " + description;
     }
 
-    link = clockifyButton.createButton(description, projectElem.textContent.trim(), description);
+    link = clockifyButton.createButton({
+        description: description,
+        projectName: projectElem.textContent.trim(),
+        taskName: description,
+        billable: false
+    });
     link.style.marginRight = '15px';
     link.style.padding = '0px';
     link.style.paddingLeft = '20px';
@@ -29,7 +34,12 @@ clockifyButton.render('.merge-request-details .detail-page-description:not(.cloc
         description = "MR" + numElem.textContent.split(" ").pop().trim().replace("!", "") + "::" + description;
     }
 
-    link = clockifyButton.createButton(description, projectElem.textContent.trim(), description);
+    link = clockifyButton.createButton({
+        description: description,
+        projectName: projectElem.textContent.trim(),
+        taskName: description,
+        billable: false
+    });
     link.style.marginRight = '15px';
     link.style.padding = '0px';
     link.style.paddingLeft = '20px';

--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -9,15 +9,20 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
         description = numElem.textContent.split(" ").pop().trim() + " " + description;
     }
 
+    var billable = Array.from($$("div.labels .gl-label-text")).some(e => e.innerText === "billable");
+
     link = clockifyButton.createButton({
         description: description,
         projectName: projectElem.textContent.trim(),
         taskName: description,
-        billable: false
+        billable: billable
     });
     link.style.marginRight = '15px';
     link.style.padding = '0px';
     link.style.paddingLeft = '20px';
+    if (billable) {
+        link.style.background = 'red';
+    }
     actionsElem.parentElement.insertBefore(link, actionsElem);
 });
 
@@ -37,8 +42,7 @@ clockifyButton.render('.merge-request-details .detail-page-description:not(.cloc
     link = clockifyButton.createButton({
         description: description,
         projectName: projectElem.textContent.trim(),
-        taskName: description,
-        billable: false
+        taskName: description
     });
     link.style.marginRight = '15px';
     link.style.padding = '0px';


### PR DESCRIPTION
Hi,

in our company we have an extensive use of gitlab issues. For our customers, we need to be able to easily calculate the number of hours spent on each issue.

Thus, we thought it would be best, if each issue in a project A matches a clockify task ind project A.

For now, the clockify browser plugin already matches the projects. We extended it, so that time is always tracked on a matching task.

Maybe this is something the community is interested in as well, so we created this PR to share it. If this does not find the way into master it is fine as well, we'd just use our own fork then.

PS: Thanks for creating such awesome software btw, it was really fun to extend.

PPS: We even did some more extensions (tag transfer from gitlab, billable settings), if this would be something you're interested in I'm happy to create another PR or extend this one.