### PR TITLE
Add back the cerb integration to the list of integrations

### DIFF
--- a/src/integrations/integrations.json
+++ b/src/integrations/integrations.json
@@ -490,5 +490,11 @@
     "link": "*://to-do.live.com/*",
     "script": "microsoft-todo.js",
     "clone": false
+  },
+  "cerb.ai": {
+    "name": "Cerb",
+    "link": "*://*.cerb.ai/*",
+    "script": "cerb.js",
+    "clone": false
   }
 }


### PR DESCRIPTION
Seems like this was accidentally removed in an earlier commit, this fixes it.