### PR TITLE
Gitlab tasks small button

### DIFF
--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -108,12 +108,19 @@ var clockifyButton = {
     },
 
     createSmallButton: (description, project) => {
-        const timeEntryOptions = {
-            description: description || "",
-            projectName: project || null,
-            taskName: null,
-            billable: null
-        };
+        let timeEntryOptions;
+        if (typeof description === 'object') {
+            // mode: only one parameter that contains the options
+            timeEntryOptions = description;
+        } else {
+            // legacy mode: multiple parameters
+            timeEntryOptions = {
+                description: description || "",
+                projectName: project || null,
+                taskName: null,
+                billable: null
+            };
+        }
 
         const button = document.createElement('a');
         let title = invokeIfFunction(timeEntryOptions.description);


### PR DESCRIPTION
Added possibility to pass a a full timeEntryOptions object to small button creation. This enables tasks and tags synchronization for small button, as requested here: https://github.com/clockify/browser-extension/pull/82#issuecomment-628779904

PS: Obviously the individual integrations will need to be changed to use that option. This PR merely gives them the option to do so.