### PR TITLE
Time inputs as addition to the time button

### DIFF
--- a/src/application-types/extension.js
+++ b/src/application-types/extension.js
@@ -180,12 +180,12 @@ export class Extension {
     startTimer(request, sendResponse) {
         startTimer(request.timeEntryOptions)
             .then((response) => {
-                if (!response.message) {
+                if (response.status === 201) {
                     window.inProgress = true;
                     this.setIcon(getIconStatus().timeEntryStarted);
                     getBrowser().extension.getBackgroundPage().addPomodoroTimer();
-                    sendResponse({status: 200, data: response})
                 }
+                sendResponse(response);
             })
     }
 
@@ -195,14 +195,7 @@ export class Extension {
         request.timeEntryOptions.end = end;
 
         startTimer(request.timeEntryOptions)
-            .then((response) => {
-                if (!response.message) {
-                    sendResponse({ status: 201, data: response })
-                } else {
-                    response.status = response.code;
-                    sendResponse(response);
-                }
-            })
+            .then(sendResponse);
     }
 
     getEntryInProgressForBrowserIcon() {

--- a/src/application-types/extension.js
+++ b/src/application-types/extension.js
@@ -132,6 +132,9 @@ export class Extension {
                 case 'startWithDescription':
                     this.startNewEntry(request, sendResponse);
                     break;
+                case 'submitTime':
+                    this.submitTime(request, sendResponse);
+                    break;
             }
             return true;
         });
@@ -182,6 +185,22 @@ export class Extension {
                     this.setIcon(getIconStatus().timeEntryStarted);
                     getBrowser().extension.getBackgroundPage().addPomodoroTimer();
                     sendResponse({status: 200, data: response})
+                }
+            })
+    }
+
+    submitTime(request, sendResponse) {
+        const end = new Date();
+        request.timeEntryOptions.start = new Date(end.getTime() - request.totalMins * 60000);
+        request.timeEntryOptions.end = end;
+
+        startTimer(request.timeEntryOptions)
+            .then((response) => {
+                if (!response.message) {
+                    sendResponse({ status: 201, data: response })
+                } else {
+                    response.status = response.code;
+                    sendResponse(response);
                 }
             })
     }

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -1,4 +1,3 @@
-import * as _ from "lodash";
 import {TokenService} from "../services/token-service";
 import * as React from 'react';
 import {ProjectHelper} from "./project-helper";
@@ -154,7 +153,7 @@ async function startTimeEntryRequestAndFetch (timeEntryUrl, token, options) {
     const tags = options.tagNames ? await getOrCreateTags(options.tagNames) : [];
 
     let billable = options.billable;
-    if (_.isNil(billable)) {
+    if (billable === undefined || billable === null) {
         billable = project ? project.billable : false;
     }
 

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -193,8 +193,11 @@ async function startTimeEntryRequestAndFetch (timeEntryUrl, token, options) {
             taskId: task ? task.id : null
         })
     });
-        return fetch(timeEntryRequest)
-            .then(response => response.json());
+
+    return fetch(timeEntryRequest)
+        .then(response =>  {
+            return { status: response.status, data: response.json() };
+        });
 }
 
 export async function getDefaultProjectBackground() {

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -162,7 +162,8 @@ async function startTimeEntryRequestAndFetch (timeEntryUrl, token, options) {
         method: 'POST',
         headers: headers,
         body: JSON.stringify({
-            start: new Date(),
+            start: options.start || new Date(),
+            end: options.end, // can be undefined
             description: options.description,
             billable: billable,
             projectId: project ? project.id : null,

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -125,7 +125,7 @@ async function getOrCreateTask(token, project, taskName) {
 
     if (task) {
         return task;
-    } else if (localStorageService.get('createObjects')) {
+    } else if (JSON.parse(localStorageService.get('createObjects'), false)) {
         return await createTask(token, project.id, taskName);
     }
 }
@@ -144,7 +144,7 @@ async function getOrCreateTags(tagNames) {
         const t = existingTags.find(e => e.name === n);
         if (t) {
             tags.push(t);
-        } else if (localStorageService.get('createObjects')) {
+        } else if (JSON.parse(localStorageService.get('createObjects'), false)) {
             try {
                 const r = await tagService.createTag({ name: n });
                 if (r.status === 201) {

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -196,7 +196,9 @@ async function startTimeEntryRequestAndFetch (timeEntryUrl, token, options) {
 
     return fetch(timeEntryRequest)
         .then(response =>  {
-            return { status: response.status, data: response.json() };
+            return response.json().then(json => {
+                return { status: response.status, data: json };
+            });
         });
 }
 

--- a/src/helpers/integration-helper.js
+++ b/src/helpers/integration-helper.js
@@ -125,7 +125,7 @@ async function getOrCreateTask(token, project, taskName) {
 
     if (task) {
         return task;
-    } else if (JSON.parse(localStorageService.get('createObjects'), false)) {
+    } else if (JSON.parse(localStorageService.get('createObjects', false))) {
         return await createTask(token, project.id, taskName);
     }
 }
@@ -144,7 +144,7 @@ async function getOrCreateTags(tagNames) {
         const t = existingTags.find(e => e.name === n);
         if (t) {
             tags.push(t);
-        } else if (JSON.parse(localStorageService.get('createObjects'), false)) {
+        } else if (JSON.parse(localStorageService.get('createObjects', false))) {
             try {
                 const r = await tagService.createTag({ name: n });
                 if (r.status === 201) {

--- a/src/helpers/project-helper.js
+++ b/src/helpers/project-helper.js
@@ -154,7 +154,7 @@ export class ProjectHelper {
                     return project;
                 }
 
-                if (localStorageService.get('createObjects')) {
+                if (JSON.parse(localStorageService.get('createObjects'), false)) {
                     return projectService.createProject({
                         name: projectName,
                         color: "#03a9f4"

--- a/src/helpers/project-helper.js
+++ b/src/helpers/project-helper.js
@@ -154,7 +154,7 @@ export class ProjectHelper {
                     return project;
                 }
 
-                if (JSON.parse(localStorageService.get('createObjects'), false)) {
+                if (JSON.parse(localStorageService.get('createObjects', false))) {
                     return projectService.createProject({
                         name: projectName,
                         color: "#03a9f4"

--- a/src/helpers/project-helper.js
+++ b/src/helpers/project-helper.js
@@ -150,7 +150,11 @@ export class ProjectHelper {
                     project = response.data.filter(project => project.name === projectName)[0];
                 }
 
-                if (!project && localStorageService.get('createObjects')) {
+                if (project) {
+                    return project;
+                }
+
+                if (localStorageService.get('createObjects')) {
                     return projectService.createProject({
                         name: projectName,
                         color: "#03a9f4"
@@ -166,7 +170,7 @@ export class ProjectHelper {
                         return this.getDefaultProject();
                     });
                 } else {
-                    return project;
+                    return this.getDefaultProject();
                 }
             });
         } else {

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -168,6 +168,8 @@ var clockifyButton = {
     createInput: (timeEntryOptions) => {
         const form = document.createElement('form');
         const input = document.createElement('input');
+        input.classList.add("clockify-input");
+        input.classList.add("clockify-input-default");
         input.setAttribute("placeholder", "Format: 4d 5h 30m");
 
         form.appendChild(input);
@@ -178,6 +180,7 @@ var clockifyButton = {
                 const m = time.match(/^(\d+d)?\s*(\d+h)?\s*(\d+m)?$/);
                 if (m) {
                     input.readOnly = true;
+                    input.value = "Submitting...";
 
                     var totalMins = 8 * 60 * parseInt(m[1] || 0, 10) +
                         60 * parseInt(m[2] || 0, 10) +
@@ -188,37 +191,16 @@ var clockifyButton = {
                         totalMins: totalMins,
                         timeEntryOptions: timeEntryOptions,
                     }, (response) => {
+                        input.value = "";
                         if (!response || response.status !== 201) {
-                            input.style.background = '#ff0000';
-                            input.value = "Error: " + (response && response.code);
                             console.error(response);
-                
-                            setTimeout(() => {
-                                input.value = time;
-                                input.style.background = 'white';
-                                input.readOnly = false;
-                            }, 1000);
+                            inputMessage(input, "Error: " + (response && response.code), "error");
                         } else {
-                            input.style.background = '#00ff00';
-                            input.value = "YEY! Submission successful!";
-                
-                            setTimeout(() => {
-                                input.value = "";
-                                input.style.background = 'white';
-                                input.readOnly = false;
-                            }, 1000);
+                            inputMessage(input, "Submission successful!", "success");
                         }
                     });
                 } else {
-                    input.readOnly = true;
-                    input.style.background = '#ff0000';
-                    input.value = "Input format: 4d 3h 30m";
-        
-                    setTimeout(() => {
-                        input.value = time;
-                        input.style.background = 'white';
-                        input.readOnly = false;
-                    }, 1000);
+                    inputMessage(input, "Input format: 4d 3h 30m", "error");
                 }
             } catch (e) {
                 console.error(e);
@@ -264,6 +246,25 @@ function createTag(name, className, textContent) {
     }
 
     return tag;
+}
+
+function inputMessage(input, msg, type) {
+    input.readOnly = true;
+    const oldValue = input.value;
+    input.classList.remove("clockify-input-default");
+    input.classList.remove("clockify-input-error");
+    input.classList.remove("clockify-input-success");
+    input.classList.add("clockify-input-" + type);
+    input.value = msg;
+
+    setTimeout(() => {
+        input.value = oldValue;
+        input.classList.remove("clockify-input-default");
+        input.classList.remove("clockify-input-error");
+        input.classList.remove("clockify-input-success");
+        input.classList.add("clockify-input-default");
+        input.readOnly = false;
+    }, 1000);
 }
 
 function setButtonProperties(button, title, active) {

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -194,7 +194,13 @@ var clockifyButton = {
                         input.value = "";
                         if (!response || response.status !== 201) {
                             console.error(response);
-                            inputMessage(input, "Error: " + (response && response.code), "error");
+                            inputMessage(input, "Error: " + (response && response.status), "error");
+
+                            if (response && response.status === 400) {
+                                // project/task/etc. can be configured to be mandatory; this can result in a code 400 during
+                                // time entry creation
+                                alert("Can't log time without project/task/description or tags. Please create your time entry using the dashboard or edit your workspace settings.");
+                            }
                         } else {
                             inputMessage(input, "Submission successful!", "success");
                         }

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -219,52 +219,9 @@ var clockifyButton = {
             return false;
         };
 
-        // setButtonProperties(button, title, active);
-    
-        // button.addEventListener('click', (e) => {
-        //     e.stopPropagation();
-        // });
-    
-        // button.onclick = () => {
-        //     title = invokeIfFunction(timeEntryOptions.description);
-        //     if (title && title === clockifyButton.inProgressDescription) {
-        //         aBrowser.runtime.sendMessage({eventName: 'endInProgress'}, (response) => {
-        //             if (response.status === 400) {
-        //                 alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
-        //             } else {
-        //                 clockifyButton.inProgressDescription = null;
-        //                 active = false;
-        //                 setButtonProperties(button, title, active);
-        //                 aBrowser.storage.sync.set({
-        //                     timeEntryInProgress: null
-        //                 });
-        //             }
-        //         });
-        //     } else {
-        //         aBrowser.runtime.sendMessage({
-        //             eventName: 'startWithDescription',
-        //             timeEntryOptions: timeEntryOptions
-        //         }, (response) => {
-        //             if (response.status === 400) {
-        //                 alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
-        //             } else {
-        //                 active = true;
-        //                 setButtonProperties(button, title, active);
-        //                 clockifyButton.inProgressDescription = title;
-        //                 aBrowser.storage.sync.set({
-        //                     timeEntryInProgress: response.data
-        //                 });
-        //             }
-        //         });
-        //     }
-    
-        // };
-        // clockifyButton.links.push(button);
-
         return form;
     }
 };
-
 
 function fetchEntryInProgress(callback) {
     aBrowser.runtime.sendMessage({eventName: "getEntryInProgress"}, (response) => {

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -151,8 +151,117 @@ var clockifyButton = {
 
         clockifyButton.links.push(button);
         return button;
+    },
+
+    createInput: (timeEntryOptions) => {
+        const form = document.createElement('form');
+        const input = document.createElement('input');
+        input.setAttribute("placeholder", "Format: 4d 5h 30m");
+
+        form.appendChild(input);
+
+        form.onsubmit = (a) => {
+            try {
+                const time = input.value;
+                const m = time.match(/^(\d+d)?\s*(\d+h)?\s*(\d+m)?$/);
+                if (m) {
+                    input.readOnly = true;
+
+                    var totalMins = 8 * 60 * parseInt(m[1] || 0, 10) +
+                        60 * parseInt(m[2] || 0, 10) +
+                        parseInt(m[3] || 0, 10);
+                    
+                    aBrowser.runtime.sendMessage({
+                        eventName: 'submitTime',
+                        totalMins: totalMins,
+                        timeEntryOptions: timeEntryOptions,
+                    }, (response) => {
+                        if (!response || response.status !== 201) {
+                            input.style.background = '#ff0000';
+                            input.value = "Error: " + (response && response.code);
+                            console.error(response);
+                
+                            setTimeout(() => {
+                                input.value = time;
+                                input.style.background = 'white';
+                                input.readOnly = false;
+                            }, 1000);
+                        } else {
+                            input.style.background = '#00ff00';
+                            input.value = "YEY! Submission successful!";
+                
+                            setTimeout(() => {
+                                input.value = "";
+                                input.style.background = 'white';
+                                input.readOnly = false;
+                            }, 1000);
+                        }
+                    });
+                } else {
+                    input.readOnly = true;
+                    input.style.background = '#ff0000';
+                    input.value = "Input format: 4d 3h 30m";
+        
+                    setTimeout(() => {
+                        input.value = time;
+                        input.style.background = 'white';
+                        input.readOnly = false;
+                    }, 1000);
+                }
+            } catch (e) {
+                console.error(e);
+            }
+
+            // don't reload the page
+            return false;
+        };
+
+        // setButtonProperties(button, title, active);
+    
+        // button.addEventListener('click', (e) => {
+        //     e.stopPropagation();
+        // });
+    
+        // button.onclick = () => {
+        //     title = invokeIfFunction(timeEntryOptions.description);
+        //     if (title && title === clockifyButton.inProgressDescription) {
+        //         aBrowser.runtime.sendMessage({eventName: 'endInProgress'}, (response) => {
+        //             if (response.status === 400) {
+        //                 alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
+        //             } else {
+        //                 clockifyButton.inProgressDescription = null;
+        //                 active = false;
+        //                 setButtonProperties(button, title, active);
+        //                 aBrowser.storage.sync.set({
+        //                     timeEntryInProgress: null
+        //                 });
+        //             }
+        //         });
+        //     } else {
+        //         aBrowser.runtime.sendMessage({
+        //             eventName: 'startWithDescription',
+        //             timeEntryOptions: timeEntryOptions
+        //         }, (response) => {
+        //             if (response.status === 400) {
+        //                 alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
+        //             } else {
+        //                 active = true;
+        //                 setButtonProperties(button, title, active);
+        //                 clockifyButton.inProgressDescription = title;
+        //                 aBrowser.storage.sync.set({
+        //                     timeEntryInProgress: response.data
+        //                 });
+        //             }
+        //         });
+        //     }
+    
+        // };
+        // clockifyButton.links.push(button);
+
+        return form;
     }
 };
+
 
 function fetchEntryInProgress(callback) {
     aBrowser.runtime.sendMessage({eventName: "getEntryInProgress"}, (response) => {

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -109,7 +109,7 @@ var clockifyButton = {
         return clockifyButton.createButton(options);
     },
 
-    createInput: (timeEntryOptions) => {
+    createInput: (options) => {
         const form = document.createElement('form');
         const input = document.createElement('input');
         input.classList.add("clockify-input");
@@ -119,6 +119,7 @@ var clockifyButton = {
         form.appendChild(input);
 
         form.onsubmit = (a) => {
+            const timeEntryOptionsInvoked = objInvokeIfFunction(options);
             try {
                 const time = input.value;
                 const m = time.match(/^(\d+d)?\s*(\d+h)?\s*(\d+m)?$/);
@@ -133,7 +134,7 @@ var clockifyButton = {
                     aBrowser.runtime.sendMessage({
                         eventName: 'submitTime',
                         totalMins: totalMins,
-                        timeEntryOptions: timeEntryOptions,
+                        timeEntryOptions: timeEntryOptionsInvoked,
                     }, (response) => {
                         input.value = "";
                         if (!response || response.status !== 201) {

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -90,7 +90,7 @@ var clockifyButton = {
                     timeEntryOptions: timeEntryOptions
                 }, (response) => {
                     if (response.status === 400) {
-                        alert("Can't start entry without project/task/description or tags. Please edit your time entry.");
+                        alert("Can't start entry without project/task/description or tags. Please edit your time entry. Please create your time entry using the dashboard or edit your workspace settings.");
                     } else {
                         active = true;
                         setButtonProperties(button, title, active);
@@ -148,7 +148,7 @@ var clockifyButton = {
                     timeEntryOptions: timeEntryOptions
                 }, (response) => {
                     if (response.status === 400) {
-                        alert("Can't start entry without project/task/description or tags. Please edit your time entry.");
+                        alert("Can't start entry without project/task/description or tags. Please edit your time entry. Please create your time entry using the dashboard or edit your workspace settings.");
                     } else {
                         active = true;
                         setButtonProperties(button, title, active);

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -74,7 +74,7 @@ var clockifyButton = {
             if (title && title === clockifyButton.inProgressDescription) {
                 aBrowser.runtime.sendMessage({eventName: 'endInProgress'}, (response) => {
                     if (response.status === 400) {
-                        alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
+                        alert("Can't end entry without project/task/description or tags. Please edit your time entry.");
                     } else {
                         clockifyButton.inProgressDescription = null;
                         active = false;
@@ -90,7 +90,7 @@ var clockifyButton = {
                     timeEntryOptions: timeEntryOptions
                 }, (response) => {
                     if (response.status === 400) {
-                        alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
+                        alert("Can't start entry without project/task/description or tags. Please edit your time entry.");
                     } else {
                         active = true;
                         setButtonProperties(button, title, active);
@@ -132,7 +132,7 @@ var clockifyButton = {
             if (clockifyButton.inProgressDescription === title) {
                 aBrowser.runtime.sendMessage({eventName: 'endInProgress'}, (response) => {
                     if (response.status === 400) {
-                        alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
+                        alert("Can't end entry without project/task/description or tags. Please edit your time entry.");
                     } else {
                         clockifyButton.inProgressDescription = null;
                         active = false;
@@ -148,7 +148,7 @@ var clockifyButton = {
                     timeEntryOptions: timeEntryOptions
                 }, (response) => {
                     if (response.status === 400) {
-                        alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
+                        alert("Can't start entry without project/task/description or tags. Please edit your time entry.");
                     } else {
                         active = true;
                         setButtonProperties(button, title, active);

--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -28,7 +28,6 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
         taskName: description,
         tagNames: tags
     });
-    inputForm.firstChild.setAttribute("class", "form-control");
     actionsElem.parentElement.insertBefore(inputForm, actionsElem);
 });
 

--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -44,14 +44,25 @@ clockifyButton.render('.merge-request-details .detail-page-description:not(.cloc
         description = "MR" + numElem.textContent.split(" ").pop().trim().replace("!", "") + "::" + description;
     }
 
+    var tags = Array.from($$("div.labels .gl-label-text")).map(e => e.innerText);
+
     link = clockifyButton.createButton({
         description: description,
         projectName: projectElem.textContent.trim(),
-        taskName: description
+        taskName: description,
+        tagNames: tags
     });
     link.style.marginRight = '15px';
     link.style.padding = '0px';
     link.style.paddingLeft = '20px';
     actionsElem.parentElement.insertBefore(link, actionsElem);
+
+    var inputForm = clockifyButton.createInput({
+        description: description,
+        projectName: projectElem.textContent.trim(),
+        taskName: description,
+        tagNames: tags
+    });
+    actionsElem.parentElement.insertBefore(inputForm, actionsElem);
 });
 

--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -21,6 +21,15 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
     link.style.padding = '0px';
     link.style.paddingLeft = '20px';
     actionsElem.parentElement.insertBefore(link, actionsElem);
+
+    var inputForm = clockifyButton.createInput({
+        description: description,
+        projectName: projectElem.textContent.trim(),
+        taskName: description,
+        tagNames: tags
+    });
+    inputForm.firstChild.setAttribute("class", "form-control");
+    actionsElem.parentElement.insertBefore(inputForm, actionsElem);
 });
 
 clockifyButton.render('.merge-request-details .detail-page-description:not(.clockify)', {observe: true}, (elem) => {

--- a/src/integrations/style.css
+++ b/src/integrations/style.css
@@ -12,6 +12,31 @@
   background: url("data:image/svg+xml,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M10.3204 5.49929L13.9454 1.82335L14.9831 2.87479L11.358 6.55073L10.3204 5.49929ZM8.85151 9.25581C8.14209 9.25581 7.56735 8.67078 7.56735 7.94843C7.56735 7.22682 8.14209 6.64102 8.85151 6.64102C9.56092 6.64102 10.1357 7.22682 10.1357 7.94843C10.1357 8.67078 9.56092 9.25581 8.85151 9.25581ZM15 13.0527L13.9624 14.1049L10.3373 10.4289L11.3749 9.37668L15 13.0527Z' fill='%2360747C'/%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.88892 13.6023C9.61963 13.6023 10.3158 13.4546 10.9539 13.1919L12.7244 14.9881C11.5889 15.6306 10.282 16 8.88892 16C4.53235 16 1 12.4181 1 8.00036C1 3.58192 4.53235 0 8.88892 0C10.268 0 11.5632 0.360432 12.6906 0.991004L10.9494 2.75733C10.3121 2.49615 9.61818 2.3484 8.88892 2.3484C5.83785 2.3484 3.36446 4.86768 3.36446 7.97575C3.36446 11.083 5.83785 13.6023 8.88892 13.6023Z' fill='%2360747C'/%3E%3C/svg%3E") left center no-repeat;
 }
 
+.clockify-input {
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 2px;
+  padding: 0 .75rem;
+}
+
+.clockify-input-default {
+  border-color: #c6d2d9;
+  color: #333;
+  background-color: white;
+}
+
+.clockify-input-success {
+  border-color: #1aaa55;
+  color: #168f48;
+  background-color: #d4edda;
+}
+
+.clockify-input-error {
+  border-color: #aa1a1a;
+  color: #8f1616;
+  background-color: #f8d7da;
+}
+
 .backlog-table-body .user-story-name a.clockify-button-inactive{
   flex-grow: 0;
 }


### PR DESCRIPTION
Hi,

besides #80 we actually implemented another extension to the plugin to make it more useful for our internal processes.

A demo says more than a thousand words: 
![peek](https://user-images.githubusercontent.com/7511464/82050485-82278b80-96b8-11ea-8b31-a8fcfb79df8b.gif)

Basically, we found that often we forget clicking the time buttons, but were quite satisfied with the simplicity of gitlabs minimalistic time tracking, where you can just add durations like `1h 30m`. However, we cannot use gitblabs time tracking as it is always visible to everyone who has access to the issues and we did not have high hopes of changing that. So we implemented that feature into the clockify plugin.

This might be a feature specific to how we use time tracking. If this does not match your philosophy of time tracking, we'll just maintain our fork :)

However, if you are interested in this feature we might be able to put some more work into it to make it public-production-ready (styling, etc.).