### PR TITLE
Button parameters as functions

### DIFF
--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -60,7 +60,7 @@ var clockifyButton = {
         }
 
         const button = document.createElement('a');
-        let title = invokeIfFunction(timeEntryOptions.description);
+        const title = invokeIfFunction(timeEntryOptions.description);
         let active = title && title === clockifyButton.inProgressDescription;
 
         setButtonProperties(button, title, active);
@@ -70,7 +70,8 @@ var clockifyButton = {
         });
 
         button.onclick = () => {
-            title = invokeIfFunction(timeEntryOptions.description);
+            const timeEntryOptionsInvoked = objInvokeIfFunction(timeEntryOptions);
+            const title = timeEntryOptionsInvoked.description;
             if (title && title === clockifyButton.inProgressDescription) {
                 aBrowser.runtime.sendMessage({eventName: 'endInProgress'}, (response) => {
                     if (response.status === 400) {
@@ -87,7 +88,7 @@ var clockifyButton = {
             } else {
                 aBrowser.runtime.sendMessage({
                     eventName: 'startWithDescription',
-                    timeEntryOptions: timeEntryOptions
+                    timeEntryOptions: timeEntryOptionsInvoked
                 }, (response) => {
                     if (response.status === 400) {
                         alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
@@ -129,6 +130,8 @@ var clockifyButton = {
         setButtonProperties(button, title, active);
 
         button.onclick = () => {
+            const timeEntryOptionsInvoked = objInvokeIfFunction(timeEntryOptions);
+            const title = timeEntryOptionsInvoked.description;
             if (clockifyButton.inProgressDescription === title) {
                 aBrowser.runtime.sendMessage({eventName: 'endInProgress'}, (response) => {
                     if (response.status === 400) {
@@ -145,7 +148,7 @@ var clockifyButton = {
             } else {
                 aBrowser.runtime.sendMessage({
                     eventName: 'startWithDescription',
-                    timeEntryOptions: timeEntryOptions
+                    timeEntryOptions: timeEntryOptionsInvoked
                 }, (response) => {
                     if (response.status === 400) {
                         alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
@@ -187,6 +190,14 @@ function invokeIfFunction(trial) {
         return trial();
     }
     return trial;
+}
+
+function objInvokeIfFunction(obj) {
+    const result = {};
+    for (const key of Object.keys(obj)) {
+        result[key] = invokeIfFunction(obj[key]);
+    }
+    return result;
 }
 
 function createTag(name, className, textContent) {

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -44,23 +44,17 @@ var clockifyButton = {
             renderer(element);
         }
     },
+
     createButton: (description, project, task) => {
-        let timeEntryOptions;
-        if (typeof description === 'object') {
-            // mode: only one parameter that contains the options
-            timeEntryOptions = description;
-        } else {
-            // legacy mode: multiple parameters
-            timeEntryOptions = {
-                description: description || "",
-                projectName: project || null,
-                taskName: task || null,
-                billable: null
-            };
-        }
+        const options = objectFromParams(description, project, task);
 
         const button = document.createElement('a');
-        const title = invokeIfFunction(timeEntryOptions.description);
+
+        if (options.small) {
+            button.classList.add('small');
+        }
+
+        const title = invokeIfFunction(options.description);
         let active = title && title === clockifyButton.inProgressDescription;
 
         setButtonProperties(button, title, active);
@@ -70,7 +64,7 @@ var clockifyButton = {
         });
 
         button.onclick = () => {
-            const timeEntryOptionsInvoked = objInvokeIfFunction(timeEntryOptions);
+            const timeEntryOptionsInvoked = objInvokeIfFunction(options);
             const title = timeEntryOptionsInvoked.description;
             if (title && title === clockifyButton.inProgressDescription) {
                 aBrowser.runtime.sendMessage({eventName: 'endInProgress'}, (response) => {
@@ -109,11 +103,27 @@ var clockifyButton = {
     },
 
     createSmallButton: (description, project) => {
-        const button = clockifyButton.createButton(description, project);
-        button.classList.add('small');
-        return button;
+        const options = objectFromParams(description, project);
+        options.small = true;
+
+        return clockifyButton.createButton(options);
     }
 };
+
+function objectFromParams(description, project, task) {
+    if (typeof description === 'object') {
+        // mode: only one parameter that contains the options
+        return description;
+    } else {
+        // legacy mode: multiple parameters
+        return {
+            description: description || "",
+            projectName: project || null,
+            taskName: task || null,
+            billable: null
+        };
+    }
+}
 
 function fetchEntryInProgress(callback) {
     aBrowser.runtime.sendMessage({eventName: "getEntryInProgress"}, (response) => {

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -109,62 +109,8 @@ var clockifyButton = {
     },
 
     createSmallButton: (description, project) => {
-        let timeEntryOptions;
-        if (typeof description === 'object') {
-            // mode: only one parameter that contains the options
-            timeEntryOptions = description;
-        } else {
-            // legacy mode: multiple parameters
-            timeEntryOptions = {
-                description: description || "",
-                projectName: project || null,
-                taskName: null,
-                billable: null
-            };
-        }
-
-        const button = document.createElement('a');
-        let title = invokeIfFunction(timeEntryOptions.description);
-        let active = clockifyButton.inProgressDescription === title;
+        const button = clockifyButton.createButton(description, project);
         button.classList.add('small');
-        setButtonProperties(button, title, active);
-
-        button.onclick = () => {
-            const timeEntryOptionsInvoked = objInvokeIfFunction(timeEntryOptions);
-            const title = timeEntryOptionsInvoked.description;
-            if (clockifyButton.inProgressDescription === title) {
-                aBrowser.runtime.sendMessage({eventName: 'endInProgress'}, (response) => {
-                    if (response.status === 400) {
-                        alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
-                    } else {
-                        clockifyButton.inProgressDescription = null;
-                        active = false;
-                        setButtonProperties(button, title, active);
-                        aBrowser.storage.sync.set({
-                            timeEntryInProgress: null
-                        });
-                    }
-                });
-            } else {
-                aBrowser.runtime.sendMessage({
-                    eventName: 'startWithDescription',
-                    timeEntryOptions: timeEntryOptionsInvoked
-                }, (response) => {
-                    if (response.status === 400) {
-                        alert("Can't end entry without project/task/description or tags.Please edit your time entry.");
-                    } else {
-                        active = true;
-                        setButtonProperties(button, title, active);
-                        clockifyButton.inProgressDescription = title;
-                        aBrowser.storage.sync.set({
-                            timeEntryInProgress: response.data
-                        });
-                    }
-                });
-            }
-        };
-
-        clockifyButton.links.push(button);
         return button;
     }
 };

--- a/src/integrations/button.js
+++ b/src/integrations/button.js
@@ -50,7 +50,7 @@ var clockifyButton = {
 
         const button = document.createElement('a');
 
-        if (options.small) {
+        if (invokeIfFunction(options.small)) {
             button.classList.add('small');
         }
 

--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -9,7 +9,7 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
         description = numElem.textContent.split(" ").pop().trim() + " " + description;
     }
 
-    var tags = Array.from($$("div.labels .gl-label-text")).map(e => e.innerText);
+    var tags = () => Array.from($$("div.labels .gl-label-text")).map(e => e.innerText);
 
     link = clockifyButton.createButton({
         description: description,


### PR DESCRIPTION
Before #80 broke it, integrations were able to pass time entry description as function.

As I've noted in https://github.com/clockify/browser-extension/pull/82#issuecomment-630841085, this allows for dynamic evaluation of the properties at time of button click. As possible use case would be the following: If I am in an gitlab issue, change the tags of that issue and then start logging my time I want my new tag to be synced without reloading the page.

This PR fixes and generalizes this feature or all parameters, including for example the tags. I also took the freedom to remove the code duplication between normal and small button.

Finally, I implemented the aforementioned behavior for gitlab tags.