### PR TITLE
Wrong Jira issue number on sidebar

### DIFF
--- a/src/integrations/atlassian.js
+++ b/src/integrations/atlassian.js
@@ -166,7 +166,7 @@ clockifyButton.render(
         const root = $('div[id="ghx-detail-view"]');
         const container =
             $('div[id="jira-issue-header"] > div > div > div > div > div > div:first-child > div > div', elem);
-        const issueNumber = $('a > span > span', container.lastChild).textContent;
+        const issueNumber = $('div > div:last-child > div > div > a > span > span', container.lastChild).textContent;
         const desc = $('h1', root).textContent;
 
         // Try to find the project


### PR DESCRIPTION
This fixes an issue for the button created when the task is on the sidebar (on the backlog for example). In case a task was a subtask of another, it was taking the issue number of the parent instead of the child.