### PR TITLE
Support for Government Tenants and Office 365

### DIFF
--- a/src/integrations/integrations.json
+++ b/src/integrations/integrations.json
@@ -19,7 +19,7 @@
   },
   "azure.com": {
     "name": "Azure",
-    "link": "*://*.azure.com/*",
+    "link": "*://*.azure.*/*",
     "script": "azure.js",
     "clone": false
   },
@@ -235,7 +235,7 @@
   },
   "outlook.live.com": {
     "name": "Outlook",
-    "link": "*://outlook.live.com/*",
+    "link": "*://outlook.*/*",
     "script": "outlook.js",
     "clone": false
   },


### PR DESCRIPTION
Azure Government has the the url of portal.azure.us
Office 365 has the url outlook.office365.com
Office 365 Gov has the following url outlook.office365.us