### PR TITLE
Azure DevOps - Project name from custom field & button element fix

### DIFF
--- a/src/integrations/azure.js
+++ b/src/integrations/azure.js
@@ -1,8 +1,8 @@
-clockifyButton.render('.work-item-form-headerContent:not(.clockify)', {observe: true}, function (elem) {
+clockifyButton.render('.work-item-form-headerContent:not(.clockify,.flex-row)', {observe: true}, function (elem) {
   var link, itemId, description, project;
   itemId =  $('.work-item-form-id > span', elem).textContent;
   description = $('.work-item-form-title input', elem).value;
-  project = $(".navigation-container .project-item .text-ellipsis").textContent;
+  project = $("input[aria-label='Clockify Project']") ? $("input[aria-label='Clockify Project']").value : $(".navigation-container .project-item .text-ellipsis").textContent;
   link = clockifyButton.createButton("#" + itemId + " " + description, project);
   link.style.display = "block";
   link.style.paddingTop = "0";


### PR DESCRIPTION
This enables you to create a custom field labeled "Clockify Project" for Work Items in Azure DevOps and set your Clockify Project there. If no "Clockify Project"-field exists, it will just use the regular project name like before. 

![image](https://user-images.githubusercontent.com/71820805/105363297-2c6a9200-5bfc-11eb-8a38-4d4eab244dff.png)


_I also did a minor fix to only select the correct element for the Clockify-button._