### PR TITLE
Fix repo name on GitHub repo

### DIFF
--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -1,7 +1,7 @@
 clockifyButton.render('.gh-header-actions:not(.clockify)', {observe: true}, function (elem) {
   issueId = $(".gh-header-number").innerText;
   description = issueId + " " + $(".js-issue-title").innerText;
-  project = $("[data-pjax='#js-repo-pjax-container']").innerText;
+  project = $("[data-pjax='#repo-content-pjax-container']").innerText;
   tags = () => Array.from($$(".IssueLabel")).map(e => e.innerText),
 
   link = clockifyButton.createButton({


### PR DESCRIPTION
Updates the GitHub integration, fixes #172 

I've manually tested this by building and loading the development extension for Chrome and then logging time via the dev extension into Clockify.

Unrelated: I noticed a missing dependency after `npm i` -- @hypnosphi/create-react-context. I also installed this to build the extension but I've left this out of the PR.