### PR TITLE
generic integration to integrate clockify in any webpage that includes a special placeholder

### DIFF
--- a/src/integrations/generic-integration.js
+++ b/src/integrations/generic-integration.js
@@ -1,0 +1,21 @@
+clockifyButton.render(
+  '.clockify-container:not(.clockify)',
+  {observe: true}, 
+  (elem) => {
+    const description = ("description" in elem.dataset) ? elem.dataset.description : "";
+    const project = ("project" in elem.dataset) ? elem.dataset.project : null;
+    const task = ("task" in elem.dataset) ? elem.dataset.task : null;
+    const tags = ("tags" in elem.dataset) ? elem.dataset.tags.split(",") : [];
+    const small = "small" in elem.dataset;
+
+    const link = clockifyButton.createButton({
+        description: description,
+        projectName: project,
+        taskName: task,
+        tagNames: tags,
+        small: small,
+    });
+
+    elem.appendChild(link);
+  },
+);

--- a/src/integrations/integrations.json
+++ b/src/integrations/integrations.json
@@ -131,6 +131,12 @@
     "script": "front.js",
     "clone": false
   },
+  "generic-integration": {
+    "name": "Generic Integration",
+    "link": "*://*/*",
+    "script": "generic-integration.js",
+    "clone": false
+  },
   "getflow.com": {
     "name": "Getflow",
     "link": "*://app.getflow.com/*",


### PR DESCRIPTION
This adds a generic integration that looks in any webpage for a DOM element having the class "clockify-container" and adds the clockify button to it. This allows any webpage to easily integrate clockify without the need of adding a custom integration to the browser extension. Espcially this would "allow for custom integrations without having to extend the extension" as requested in #58 (though by an alternative approach without GUI).

By adding data attributes to the placeholder DOM element one can controll the description, project, task, tags and whether the small version of the button shall be used. For example, the placeholder can be defined as follows:

`<div class="clockify-container" data-description="This is the description" data-project="My Project" data-task="Task 1" data-tags="tag1,tag2,tag3" data-small></div>`