### PR TITLE
Create integration for Github Projects

### DIFF
--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -1,3 +1,37 @@
+// For the projects detail page
+clockifyButton.render(
+  'div[data-test-id="side-panel"] aside ul:not(.clockify)',
+  { observe: true, noDebounce: true },
+  (elem) => {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (
+          mutation.target.attributes["data-test-id"]?.value ===
+          "side-panel-title"
+        ) {
+          const description = mutation.target.querySelector("h2 span").innerText
+          const issueNum = mutation.target.querySelector("a").innerText
+
+          const link = clockifyButton.createButton(`${issueNum} ${description}`)
+          const li = document.createElement("li")
+          li.style.marginLeft = "8px"
+          li.style.padding = "6px 8px"
+          li.style.listStyle = "none"
+          li.appendChild(link)
+          elem.append(li)
+        }
+      })
+    })
+
+    observer.observe(document.querySelector("#__primerPortalRoot__ header"), {
+      childList: true,
+      subtree: true,
+    })
+  },
+  'div[data-test-id="side-panel"]'
+)
+
+// For the issues page
 clockifyButton.render('.gh-header-actions:not(.clockify)', {observe: true}, function (elem) {
   issueId = $(".gh-header-number").innerText;
   description = issueId + " " + $(".js-issue-title").innerText;

--- a/src/popupDlg/clockifyButton.js
+++ b/src/popupDlg/clockifyButton.js
@@ -10,7 +10,12 @@ var clockifyButton = {
     render: (selector, opts, renderer, mutationSelector) => {
         if (opts.observe) { 
             if (!clockifyButton.observer) {
-                clockifyButton.observer = new MutationObserver(clockifyDebounce(clockifyButton.callback, 1000));
+                if (opts.noDebounce) {
+                  clockifyButton.observer = new MutationObserver(clockifyButton.callback);
+                } else {
+                  clockifyButton.observer = new MutationObserver(clockifyDebounce(clockifyButton.callback, 1000));
+                }
+                
                 clockifyButton.observer.observe(
                     document,
                     {childList: true, subtree: true}


### PR DESCRIPTION
Add noDebounce option to clockifyButton.render opts
Closes #201

I added the noDebounce option with this integration because clockifyDebounce was not allowing the proper document mutations to be detected. If no value is specified for tis option, the behavior will be the same as it was before this change.
