### PR TITLE
Use GitLab reference identifiers in GitLab integration

### DIFF
--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -1,13 +1,16 @@
 clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', {observe: true}, (elem) => {
     var link, description,
+        projectLinkElem = $('.breadcrumbs-links li:nth-last-child(3) a'),
         numElem = $(".identifier") || $(".breadcrumbs-links li:last-child a"),
         titleElem = $(".title", elem),
         projectElem = $(".title .project-item-select-holder") || $(".breadcrumbs-list li:nth-last-child(3) .breadcrumb-item-text"),
         actionsElem = $(".detail-page-header-actions");
-    description = titleElem.textContent.trim();
-    if (numElem !== null) {
-        description = numElem.textContent.split(" ").pop().trim() + " " + description;
-    }
+
+    var title = titleElem.textContent.trim();
+    var projectRef = projectLinkElem ? projectLinkElem.href.trim().replace(location.origin + '/', '') : '';
+    var projectNum = numElem ? numElem.textContent.split(" ").pop().trim() : '';
+
+    description = (projectRef + projectNum + ' ' + title).trim();
 
     var tags = () => Array.from($$("div.labels .gl-label-text")).map(e => e.innerText);
 
@@ -33,16 +36,17 @@ clockifyButton.render('.issue-details .detail-page-description:not(.clockify)', 
 
 clockifyButton.render('.merge-request-details.issuable-details > .detail-page-description:not(.clockify)', {observe: true}, (elem) => {
     var link, description,
+        projectLinkElem = $('.breadcrumbs-links li:nth-last-child(3) a'),
         numElem = $(".identifier") || $(".breadcrumbs-links li:last-child a"),
         titleElem = $("h1.title"),
         projectElem = $(".title .project-item-select-holder") || $(".breadcrumbs-list li:nth-last-child(3) .breadcrumb-item-text"),
         actionsElem = $(".detail-page-header-actions");
 
-    description = titleElem.textContent.trim();
-
-    if (numElem !== null) {
-        description = "MR" + numElem.textContent.split(" ").pop().trim().replace("!", "") + "::" + description;
-    }
+    var title = titleElem.textContent.trim();
+    var projectRef = projectLinkElem ? projectLinkElem.href.trim().replace(location.origin + '/', '') : '';
+    var projectNum = numElem ? numElem.textContent.split(" ").pop().trim() : '';
+    
+    description = (projectRef + projectNum + ' ' + title).trim();
 
     var tags = Array.from($$("div.labels .gl-label-text")).map(e => e.innerText);
 


### PR DESCRIPTION
Update the task name for Gitlab issues and MRs to be prefixed with the full GitLab reference (including group and project identifiers) instead of just the id number.

This matches the text used for cross-project references in Markdown on GitLab. See: https://docs.gitlab.com/ee/user/markdown.html#gitlab-specific-references

The table below summarizes the changes:

|Page Type|Old|New|
|-----------|----|-----|
|Issue|`#99 Issue Title`|`org-name/project-name#99 Issue Title`|
|MR|`MR99::Issue Title`|`org-name/project-name!99 Issue Title`|

This implements https://github.com/clockify/browser-extension/issues/24