### PR TITLE
Remove invalid permission from Firefox manifest

### DIFF
--- a/manifest.firefox.dev.json
+++ b/manifest.firefox.dev.json
@@ -59,10 +59,9 @@
   "web_accessible_resources" : [
     "assets/images/*.png",
     "assets/images/*.svg",
-	 "assets/images/ui-icons/*.svg"
+	  "assets/images/ui-icons/*.svg"
   ],   
   "permissions": [
-    "background",
     "contextMenus",
     "*://*.clockify.me/*",
     "*://*/",


### PR DESCRIPTION
The `background` permission is Chrome-specific and produces a warning when used in Firefox. The browser compatibility chart on MDN confirms this: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#browser_compatibility

![image](https://user-images.githubusercontent.com/2626103/192340178-7b9919e6-e7ba-4404-8240-75836ab9398c.png)
