### PR TITLE
Change to version 2.8.5

### DIFF
--- a/manifest.chrome.dev.json
+++ b/manifest.chrome.dev.json
@@ -7,7 +7,7 @@
   "background": {
     "service_worker": "sw.js"
   },
-  "version": "2.8.3",
+  "version": "2.8.5",
   "action": {
     "default_popup": "index.html",
     "default_title": "Clockify"

--- a/manifest.firefox.dev.json
+++ b/manifest.firefox.dev.json
@@ -35,7 +35,7 @@
       "strict_min_version": "57.0a1"
     }
   },
-  "version": "2.8.3",
+  "version": "2.8.5",
   "browser_action": {
     "default_popup": "index.html",
     "default_title": "Clockify"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Clockify",
-  "version": "2.8.3",
+  "version": "2.8.5",
   "description": "Clockify App 100% Free Time Tracker",
   "main": "./main.js",
   "productName": "Clockify",


### PR DESCRIPTION
Change to version 2.8.5 because the current version in webstore (chrome) does not contain latest integration (Jetbrains Space Support)