### PR TITLE
Azure Devops Integration: populate tags from Work Item

### DIFF
--- a/src/integrations/azure.js
+++ b/src/integrations/azure.js
@@ -10,12 +10,13 @@ clockifyButton.render(
 			: $('.navigation-container .project-item .text-ellipsis').textContent;
 		tagNames = () =>
 			Array.from(
-				$$('.tags-items-container .tag-item:not(.tags-add-button) .tag-box')
+				$$('.work-item-view .tags-items-container .tag-item:not(.tags-add-button) .tag-box')
 			).map((e) => e.innerText);
 		link = clockifyButton.createButton({
 			description: () => '#' + itemId() + ' ' + description(),
 			projectName: project,
 			taskName: () => description(),
+			tagNames: tagNames()
 		});
 		link.style.display = 'block';
 		link.style.paddingTop = '0';


### PR DESCRIPTION
In the azure devOps integration the tags where incorrectly selected (and therefore not inserted).

The css class scopes the tag selection to the modal (or full page) work item shown.

Tested on chrome, firefox and edge