### PR TITLE
Fixes missing task ID

### DIFF
--- a/src/integrations/clickup.js
+++ b/src/integrations/clickup.js
@@ -16,7 +16,7 @@ clockifyButton.render(
 				? headerElements[2].textContent
 				: headerElements[1].textContent;
 
-			const description = () => $('.cu-task-title__overlay').textContent;
+			const description = () => $('title').text();
 			const projectName = () => folderName ?? listName;
 			const taskName = () => (folderName ? listName : '');
 			const tagNames = () =>


### PR DESCRIPTION
Fixes #249.
Since ClickUp 3.0, the task ID is missing from the description. Since the tab title has the description + task ID we can use that instead