### PR TITLE
Gitlab render issue with new breadcrumb DOM

### DIFF
--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -5,7 +5,7 @@
 
 	// Issue view & Merge Request view
 	clockifyButton.render(selectors.hanger, { observe: true }, () => {
-		const breadcrumbs = $(selectors.breadcrumbs);
+		const header = $('.detail-page-header');
 		const breadcrumbsList = Array.from($$(selectors.breadcrumbsList));
 
 		const lastBreadcrumbItemIndex = breadcrumbsList.length - 1;
@@ -49,7 +49,7 @@
 		clockifyContainer.append(link);
 		clockifyContainer.append(input);
 
-		breadcrumbs.append(clockifyContainer);
+		header.append(clockifyContainer);
 
 		console.log(projectName);
 	});


### PR DESCRIPTION
Currently the button to start the timer and input is being render outside the viewport due to an HTML DOM change at Gitlab.

**Screenshot of the problem**

![image](https://github.com/clockify/browser-extension/assets/4028517/c5f0a2cf-373e-4d6d-8aef-6d4cde5f82c0)

After this PR the timer and input is render next to the status of the Gitlab issue and pull request.

**Screenshot of the solution**

![image](https://github.com/clockify/browser-extension/assets/4028517/2b877a37-7ba6-4509-b50e-f38edeee566e)
