### PR TITLE
Feature/integration GitHub project perspective + drafts - 2024 09

### DIFF
--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -159,3 +159,34 @@ clockifyButton.render(
 		}
 	);
 })();
+
+
+// Project View (slideout detail panel)
+
+
+// Project view (table perspective)
+(async () => {
+	const ScopedSingleton = function(){
+		this.data = null;
+		try {
+			this.data = JSON.parse(document.querySelector('script#memex-items-data').textContent);
+			//console.debug(this.data);
+		}catch{}
+		return this;
+	}();
+	clockifyButton.render(
+		'div[data-testid=table-scroll-container] div[role="row"]:not(.clockify)',
+		{ observe: true },
+		(row) => {
+			console.log(row);
+			if (!row) return;
+			if (!Object.keys(row).length) return;
+			row.classList.push('react-found');
+
+			// get the hidden internal property from react, we need details..  example: "__reactProps$b30sfm8f6q7"
+			const react_props = Object.keys(row).find((k)=> k.startsWith('__reactProps$'));
+			console.log(react_props);
+		},
+		':not(.react-found)'
+	);
+})();

--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -118,6 +118,14 @@ if (typeof ScopedSingleton_GitHubProjectView === 'undefined') {
 			const project = projects.find((p) => projectName.toLowerCase().includes(p.name.toLowerCase()));
 			return project;
 		};
+
+		this.setTitleColumnIndex = (idx) => {
+			this.titleColumnIndex = idx;
+		};
+
+		this.setLabelsColumnIndex = (idx) => {
+			this.labelsColumnIndex = idx;
+		};
 	};
 }
 
@@ -215,21 +223,22 @@ if (typeof ScopedSingleton_GitHubProjectView === 'undefined') {
 			if ($('div[data-testid^=TableColumnHeader]', row)) {
 				// this is the header row. We need to locate the column position of the "Title" column.
 				const columns = $$('div[data-testid^=TableColumnHeader]', row);
+				//console.debug(columns);
 				columns.forEach((column, idx) => {
 					const column_config_name = column.getAttribute('data-testid');
 					if (column_config_name.includes('id: Title')) {
 						//console.debug('Located the "Title" column in the table view. It is at position: ', idx);
-						singleton.titleColumnIndex = idx;
+						singleton.setTitleColumnIndex(idx);
 					}
 					else if (column_config_name.includes('id: Labels')) {
 						//console.debug('Located the "Labels" column in the table view. It is at position: ', idx);
-						singleton.labelsColumnIndex = idx;
+						singleton.setLabelsColumnIndex(idx);
 					}
 				});
 				return; // we handled the header row. process nothing else.
 			}
 
-			if (!singleton.titleColumnIndex && !singleton.hasWarnedMissingTitle) {
+			if (typeof singleton.titleColumnIndex == 'undefined' && !singleton.hasWarnedMissingTitle) {
 				singleton.hasWarnedMissingTitle=true;
 				console.warn('Clockify: Unable to locate the "Title" column in the table view. Skipping processing for current page perspective.');
 				return;

--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -280,7 +280,7 @@ if (typeof ScopedSingleton_GitHubProjectView === 'undefined') {
 			}
 
 			const entry = { description: taskTitle, projectName: singleton.projectName, tagNames };
-			console.debug(entry);
+			//console.debug(entry);
 
 			const buttonOptions = {
 				...entry,

--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -52,6 +52,7 @@ if (typeof ScopedSingleton_GitHubProjectView === 'undefined') {
 		};
 
 		this.processIssueUrl = (url) => {
+			if (!url) url = window.location.href;
 			const url_parts = url.split('/');
 
 			if (url_parts.length >= 5) {

--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -102,10 +102,28 @@ clockifyButton.render(
 	async (sidepanelHeader) => {
 		await timeout({ milliseconds: 1200 });
 
+		const singleton = new ScopedSingleton_GitHubProjectView();
+		await singleton.init();
+
+		// if we couldn't locate a clockify project based one the name of the Github project, we can instead try to locate the repo name from any issue link on the board (if any exists).
+		if (!singleton.project) {
+			// first try and attain it from the page again..
+			singleton.processIssueUrl();
+
+			if (!singleton.project) {
+				console.debug('unable to locate a project based on the name of the Github project. Trying to locate the repo name from any issue link on the board (if any exists).');
+				let target = $(`[data-test-cell-is-focused="true"] a`);
+				if (target) {
+					singleton.processIssueUrl(target.getAttribute('href'));
+					//console.debug(singleton.projectName);
+				}
+			}
+		}
+
 		const issueId = text('span', sidepanelHeader);
 		const issueTitle = text('bdi', sidepanelHeader);
-		const openedIssue = $('[data-test-cell-is-focused="true"] a');
-		const repositoryName = openedIssue.href.split('/')[4];
+		//const openedIssue = $('[data-test-cell-is-focused="true"] a');
+		const repositoryName = singleton.projectName;// const repositoryName = openedIssue.href.split('/')[4];
 
 		const description = `${issueId} ${issueTitle}`;
 		const projectName = repositoryName;

--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -294,8 +294,7 @@ class ScopedSingleton_GitHubProjectView {
 
 			// append to the end of Title row. absolutely in "overlay" css mode.
 			desired_container.append(link);
-		},
-		':not(.react-found)'
+		}
 	);
 })();
 

--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -26,42 +26,6 @@ clockifyButton.render(
 	}
 );
 
-// Sidepanel issue view (project details)
-clockifyButton.render(
-	'div[data-testid="side-panel-title"]:not(.clockify)',
-	{ observe: true },
-	async (sidepanelHeader) => {
-		await timeout({ milliseconds: 1200 });
-
-		const issueId = text('span', sidepanelHeader);
-		const issueTitle = text('bdi', sidepanelHeader);
-		const openedIssue = $('[data-test-cell-is-focused="true"] a');
-		const repositoryName = openedIssue.href.split('/')[4];
-
-		const description = `${issueId} ${issueTitle}`;
-		const projectName = repositoryName;
-		const taskName = `${issueId} ${issueTitle}`;
-		const tagNames = textList('[data-testid="sidebar-field-Labels"] li');
-
-		const container = createTag('div', 'clockify-widget-container');
-
-		container.style.margin = '6px 0px';
-		container.style.display = 'flex';
-		container.style.gap = '8px';
-
-		const entry = { description, projectName, taskName, tagNames };
-
-		const link = clockifyButton.createButton(entry);
-		const input = clockifyButton.createInput(entry);
-
-		container.append(link);
-		container.append(input);
-
-		sidepanelHeader.append(container);
-	}
-);
-
-
 if (typeof ScopedSingleton_GitHubProjectView === 'undefined') {
 	function ScopedSingleton_GitHubProjectView() {
 		this.init = async () => {
@@ -128,6 +92,43 @@ if (typeof ScopedSingleton_GitHubProjectView === 'undefined') {
 		};
 	};
 }
+
+
+
+// Sidepanel issue view (project details)
+clockifyButton.render(
+	'div[data-testid="side-panel-title"]:not(.clockify)',
+	{ observe: true },
+	async (sidepanelHeader) => {
+		await timeout({ milliseconds: 1200 });
+
+		const issueId = text('span', sidepanelHeader);
+		const issueTitle = text('bdi', sidepanelHeader);
+		const openedIssue = $('[data-test-cell-is-focused="true"] a');
+		const repositoryName = openedIssue.href.split('/')[4];
+
+		const description = `${issueId} ${issueTitle}`;
+		const projectName = repositoryName;
+		const taskName = `${issueId} ${issueTitle}`;
+		const tagNames = textList('[data-testid="sidebar-field-Labels"] li');
+
+		const container = createTag('div', 'clockify-widget-container');
+
+		container.style.margin = '6px 0px';
+		container.style.display = 'flex';
+		container.style.gap = '8px';
+
+		const entry = { description, projectName, taskName, tagNames };
+
+		const link = clockifyButton.createButton(entry);
+		const input = clockifyButton.createInput(entry);
+
+		container.append(link);
+		container.append(input);
+
+		sidepanelHeader.append(container);
+	}
+);
 
 // Project View (kanban cards)
 (async () => {
@@ -309,6 +310,3 @@ if (typeof ScopedSingleton_GitHubProjectView === 'undefined') {
 		'div[data-testid=app-root] div[id^=project-view] div'
 	);
 })();
-
-// Project View (slideout detail panel, common to both Table and Kanban perspectives)
-

--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -62,49 +62,40 @@ clockifyButton.render(
 );
 
 
-const getProjectNameOnProjectView = () => {
-	const projectName = text('h1[class^=Text]');
-	return projectName;
-};
-const matchProjectNameAgainstKnownProjects = (projectName, projects) => {
-	const project = projects.find((p) => projectName.toLowerCase().includes(p.name.toLowerCase()));
-	return project;
-};
-
 class ScopedSingleton_GitHubProjectView {
-    constructor(projects) {
+	constructor(projects) {
 		this.projects=projects;
-    }
+	}
 
-    static async createInstance() {
-        const storage = await localStorage.aBrowser.storage.local.get();
-        const projects = storage.preProjectList.projectList.map((r) => {
-            return { name: r.name, id: r.id };
-        });
+	static async createInstance() {
+		const storage = await localStorage.aBrowser.storage.local.get();
+		const projects = storage.preProjectList.projectList.map((r) => {
+			return { name: r.name, id: r.id };
+		});
 
-        return new ScopedSingleton_GitHubProjectView(projects).setProjectFromPage();
-    }
+		return new ScopedSingleton_GitHubProjectView(projects).setProjectFromPage();
+	}
 
 	setProjectFromPage() {
-		this.githubProjectName = getProjectNameOnProjectView();
-		this.project = matchProjectNameAgainstKnownProjects(this.githubProjectName, this.projects);
+		this.githubProjectName = this.getProjectNameOnProjectView();
+		this.project = this.matchProjectNameAgainstKnownProjects(this.githubProjectName, this.projects);
 		if (!this.project) {
 			console.warn("Clockify: Unable to locate existing project (by name) for this github project board: "+ this.githubProjectName, this.projects.map(x=> x.name));
 			this.projectName = this.githubProjectName;
 		}
 		else {
-            //console.debug("Clockify: Located existing project for this GitHub project board: " + this.githubProjectName, this.project);
+			//console.debug("Clockify: Located existing project for this GitHub project board: " + this.githubProjectName, this.project);
 			this.projectName = this.project.name;
-        }
+		}
 		return this;
 	}
 
-    processIssueUrl(url) {
-        const url_parts = url.split('/');
+	processIssueUrl(url) {
+		const url_parts = url.split('/');
 
 		if (url_parts.length >= 5) {
 			this.githubProjectName = url_parts[4];
-			this.project = matchProjectNameAgainstKnownProjects(this.githubProjectName, this.projects);
+			this.project = this.matchProjectNameAgainstKnownProjects(this.githubProjectName, this.projects);
 			if (!this.project) {
 				let repo_url = url.substring(0, url.lastIndexOf('/issues'));
 				console.warn("Clockify: Unable to locate existing project (by name) for repo of this github project board: "+ this.githubProjectName, repo_url, this.projects.map(x=> x.name));
@@ -119,7 +110,16 @@ class ScopedSingleton_GitHubProjectView {
 			//console.debug('Clockify: URL of issue link is not in expected format: ', url);
 		}
 		return this.projectName;
-    }
+	}
+
+	getProjectNameOnProjectView = () => {
+		const projectName = text('h1[class^=Text]');
+		return projectName;
+	}
+	matchProjectNameAgainstKnownProjects = (projectName, projects) => {
+		const project = projects.find((p) => projectName.toLowerCase().includes(p.name.toLowerCase()));
+		return project;
+	}
 }
 
 // Project View (kanban cards)
@@ -206,10 +206,11 @@ class ScopedSingleton_GitHubProjectView {
 	// our selector below for clockifyButton.render Includes the first row of the table, which is the header row.
 	
 	clockifyButton.render(
-		'div[data-testid=table-root] div[data-testid=table-scroll-container] div[role="row"]:not(.clockify)',
+		'div[data-testid=table-scroll-container] div[role="row"]:not(.clockify)',
 		{ observe: true },
 		(row) => {
 			if (!row) return;
+			console.log(row);
 			if ($('div[data-testid^=TableColumnHeader]', row)) {
 				// this is the header row. We need to locate the column position of the "Title" column.
 				const columns = $$('div[data-testid^=TableColumnHeader]', row);
@@ -294,7 +295,8 @@ class ScopedSingleton_GitHubProjectView {
 
 			// append to the end of Title row. absolutely in "overlay" css mode.
 			desired_container.append(link);
-		}
+		},
+		'div[data-testid=app-root] div[id^=project-view] div'
 	);
 })();
 

--- a/src/integrations/github.js
+++ b/src/integrations/github.js
@@ -42,7 +42,7 @@ if (typeof ScopedSingleton_GitHubProjectView === 'undefined') {
 			this.githubProjectName = this.getProjectNameOnProjectView();
 			this.project = this.matchProjectNameAgainstKnownProjects(this.githubProjectName, this.projects);
 			if (!this.project) {
-				console.warn("Clockify: Unable to locate existing project (by name) for this github project board: "+ this.githubProjectName, this.projects.map(x=> x.name));
+				//console.warn("Clockify: Unable to locate existing project (by name) for this github project board: "+ this.githubProjectName, this.projects.map(x=> x.name));
 				this.projectName = this.githubProjectName;
 			}
 			else {
@@ -79,6 +79,7 @@ if (typeof ScopedSingleton_GitHubProjectView === 'undefined') {
 		};
 
 		this.matchProjectNameAgainstKnownProjects = (projectName, projects) => {
+			if (!projectName || projectName.length<1) return;
 			const project = projects.find((p) => projectName.toLowerCase().includes(p.name.toLowerCase()));
 			return project;
 		};


### PR DESCRIPTION
Implemented clockify small-button for GitHub's Project-perspective:
- Kanban
- Table
- "My Items"
- "Current Iteration"

Which by inference means it also now supports non-Issue tasks (GitHub's Project-pespective allows creation of tasks that are not tied to real GitHub Issues).
Also have code that enables pushing Labels from said tasks/issues, which works if Clockify already contains the associated Tag.

Let me know if any issues to help this PR along. 
I believe my code on line 33 might be one area of improvement. Am using a hard internal to access the local storage of the extension, to procure the list of projects - for loose comparison to the Github Project view's Project-Name.
This is because on project view, there is no other reference to the Repository, anywhere.
And React internals (__reactRoot$*) are not possible to attain.

The only "volatile" change I believe is on line 125/126, which is now processed instead on line 115. 
I don't believe it's possible that this negatively impacts backwards compatibility. 
And additionally, it relies on the github html output to retain the class names for "test-id". I see no other way to reliably select the dom elements.
But humbly request your review to verify.

In short:  
- a new per-mutation (not per selector) function(class) scoped instance is created `ScopedSingleton_GitHubProjectView`, for code-reusability purposes.
- This class scans for the singular `h1` tag in the Project view. If present, it loosely matches against the `localStorage` of the plugin's known projects. 
- If it fails to locate one (expected on the Issue List, per original implementation), it instead falls back on: 
  - The url of the page
  - The first found Issue-task in the dom elements on Project View, 
  - or The first found slideout A href (original code for Issue List), if on the Issue List instead of a project view.

Appreciate your feedback. 
My company just purchased Clockify, and we look forward to using it extensively within GitHub's Project-perspective.
But we need Clockify to work on non-issue tasks. Creating a GitHub issue for every task simply to project it into Clockify adds extreme clutter for us. And this solves that, and additionally gives users ability to initiate Clockify on GitHub Project-perspective views.

Thank you!

#### KanBan View
![image](https://github.com/user-attachments/assets/701e199c-9a22-40ef-bbbf-0a30624b36ff)

#### Table View
![image](https://github.com/user-attachments/assets/fa87e158-787c-4ee6-b12a-8fb4217a9455)

--------------------------  
#### Initiation proof of concept, pulling both "repo" / "project" and Task title.
![image](https://github.com/user-attachments/assets/4c1a29e1-e9c2-4e20-9038-cf9dc460b2e9)
