### PR TITLE
add fibery integration

### DIFF
--- a/src/integrations/fibery.js
+++ b/src/integrations/fibery.js
@@ -1,0 +1,27 @@
+// Entity Page
+clockifyButton.render(
+    '.pinned_fields:not(.clockify)',
+    { observe: true },
+    elem => {
+
+        const description = () => {
+            const titleElem = $('.title_input');
+            return titleElem ? titleElem.textContent : '';
+        };
+
+        const link = clockifyButton.createButton({
+            description
+        });
+
+        const input = clockifyButton.createInput({
+            description
+        });
+
+        elem.append(link);
+        elem.append(input);
+    }
+);
+
+// List Page
+
+// Board Page

--- a/src/integrations/integrations.json
+++ b/src/integrations/integrations.json
@@ -79,6 +79,11 @@
 		"link": "*://*.evernote.com/*",
 		"script": "evernote.js"
 	},
+	"fibery.io": {
+		"name": "Fibery",
+		"link": "*://*.fibery.io/*",
+		"script": "fibery.js"
+	},
 	"freedcamp.com": {
 		"name": "FreedCamp",
 		"link": "*://freedcamp.com/*",


### PR DESCRIPTION
## Description
This PR adds an integration with a new tool: Fibery, allowing users to track time directly in their task management tool.
I added both the time-tracking button and the time input on the Entity page under the Title.
<img width="795" alt="image" src="https://github.com/user-attachments/assets/a610f48e-0cbe-488d-8492-6b0950b52a31" />

## Testing  
- Tested on **Firefox** and **Chrome**
- Verified that the button was visible, clickable, and picking up the task title to populate the popup.

## Notes  
- Follow-ups would include other views (list, board, calendar, etc)