### PR TITLE
GitLab integration: fixed selectors for new look

### DIFF
--- a/src/integrations/selectors.json
+++ b/src/integrations/selectors.json
@@ -54,9 +54,9 @@
       "anchor": "a",
       "groupName": ".group-path",
       "id": "[data-testid=\"breadcrumb-current-link\"] a",
-      "issueTitle": "h1.title",
+      "issueTitle": "h1[data-testid=\"work-item-title\"]",
       "projectName": ".breadcrumb-item-text",
-      "label": "div.labels .gl-label-link",
+      "label": "section[data-testid=\"work-item-labels\"] span.gl-label",
       "firstSpan": "span:nth-child(1)",
       "secondSpan": "span:nth-child(2)"
     }


### PR DESCRIPTION
Since the GitLab new look update, the title and labels were not detected correctly. To fix this, I updated the selectors in the `selectors.json` file.


Before: title and labels were undefined / not found

<img width="426" alt="Bildschirmfoto 2025-05-28 um 15 56 21" src="https://github.com/user-attachments/assets/7c5e8cec-9693-4d6a-a5ad-0f22619227ca" />

After: everything detected correctly

<img width="365" alt="Bildschirmfoto 2025-05-28 um 15 56 39" src="https://github.com/user-attachments/assets/8908b2c3-065b-454a-afc4-9a330800c595" />
