### PR TITLE
Add support for tasks (child/work items) in Gitlab

### DIFF
--- a/src/integrations/gitlab.js
+++ b/src/integrations/gitlab.js
@@ -5,7 +5,8 @@
 	clockifyButton.render(
 		`
 		[data-page="projects:issues:show"] [data-testid="breadcrumb-links"]:not(.clockify),
-		[data-page="projects:merge_requests:show"] [data-testid="breadcrumb-links"]:not(.clockify)
+		[data-page="projects:merge_requests:show"] [data-testid="breadcrumb-links"]:not(.clockify),
+		[data-page="projects:work_items:show"] [data-testid="breadcrumb-links"]:not(.clockify)
 		`,
 		{ observe: true },
 		() => {


### PR DESCRIPTION
Gitlab introduced child items in their [15.3](https://about.gitlab.com/releases/2022/08/22/gitlab-15-3-released/#key-features) version in 2022? and the Start timer wasn't appearing in the task view. 

This pull request adds the Start time button to the task url.  

Issue url: https://gitlab.com/{username}/{repository}/-/issues/{number}
Task url: https://gitlab.com/{username}/{repository}/-/work_items/{number} (The data-page selector here is different)

Before
![image](https://github.com/user-attachments/assets/821cc961-77a5-4db1-adbc-b528808e094a)

After
![image](https://github.com/user-attachments/assets/146e4760-5d74-4387-99c0-4179cf946f33)